### PR TITLE
enabled setting logging level when creating Rouge155 object

### DIFF
--- a/pyrouge/Rouge155.py
+++ b/pyrouge/Rouge155.py
@@ -71,7 +71,7 @@ class Rouge155(object):
 
     """
 
-    def __init__(self, rouge_dir=None, rouge_args=None):
+    def __init__(self, rouge_dir=None, rouge_args=None, log_level=None):
         """
         Create a Rouge155 object.
 
@@ -81,7 +81,10 @@ class Rouge155(object):
                         arguments.
 
         """
-        self.log = log.get_global_console_logger()
+        if log_level is None:
+                self.log = log.get_global_console_logger()
+        else:
+                self.log = log.get_global_console_logger(log_level)		
         self.__set_dir_properties()
         self._config_file = None
         self._settings_file = self.__get_config_path()

--- a/pyrouge/utils/log.py
+++ b/pyrouge/utils/log.py
@@ -1,17 +1,17 @@
 import logging
 
 
-def get_console_logger(name):
+def get_console_logger(name,level=logging.INFO):
     logFormatter = logging.Formatter(
         "%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s")
     logger = logging.getLogger(name)
     if not logger.handlers:
-        logger.setLevel(logging.INFO)
+        logger.setLevel(level)
         ch = logging.StreamHandler()
         ch.setFormatter(logFormatter)
         logger.addHandler(ch)
     return logger
 
 
-def get_global_console_logger():
-    return get_console_logger('global')
+def get_global_console_logger(level=logging.INFO):
+    return get_console_logger('global', level)


### PR DESCRIPTION
When one uses pyrouge a lot, tons of log messages can be annoying. Setting the desired logging level from the beginning (or in accordance with one's application) could solve this.