### PR TITLE
Disable silent stemming

### DIFF
--- a/pyrouge/Rouge155.py
+++ b/pyrouge/Rouge155.py
@@ -579,7 +579,7 @@ class Rouge155(object):
             return rouge_args
 
     def __add_config_option(self, options):
-        return options + ['-m'] + [self._config_file]
+        return options + [self._config_file]
 
     def __get_config_path(self):
         if platform.system() == "Windows":


### PR DESCRIPTION
Up until this point, pyrouge has applied Porter stemming (`-m`) silently, unchangeably, and by default. There is no way to turn this off, even if the user provides an explicit set of ROUGE parameters they want to use. It's also unclear given the existing code structure that the `-m` parameter is being added, and it seems most users don't realize they are using stemming.

Applying stemming like this is a deviation from the default ROUGE parameters, and tends to fairly significantly inflate ROUGE scores across the board. For this reason, using stemming really needs to be an explicit choice the user makes, rather than being done by default.

My only change here is only deleting the `-m` when it's added separately in `__add_config_option`. This makes the set of default parameters clearer, forcing the choice to use stemming to be explicit. This may not be the right solution if some people use and cite pyrouge knowing fully that it stems by default, but my impression is that this is not the case.