### PR TITLE
Fixing dead link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,7 +150,7 @@ Installation
 ------------
 
 Instruction on installing ROUGE can be found
-`here <http://jpbalb.in/post/42675198985/figuring-out-rouge>`__.
+`here <http://www.summarizerman.com/post/42675198985/figuring-out-rouge>`__.
 
 Depending on your system, you might have to run the following commands
 as root.


### PR DESCRIPTION
It seems link the post had been moved and the redirection fails. 
- current url: <http://jpbalb.in/post/42675198985/figuring-out-rouge>
- redirecting to: <http://www.summarizerman.com//post/42675198985/figuring-out-rouge> (note the double slash)
- correct url: <http://www.summarizerman.com/post/42675198985/figuring-out-rouge>