### PR TITLE
add environment variable of ROUGE_EVAL_HOME when call ROUGE.1.5.5.pl

### DIFF
--- a/pyrouge/Rouge155.py
+++ b/pyrouge/Rouge155.py
@@ -334,9 +334,12 @@ class Rouge155(object):
         self.write_config(system_id=system_id)
         options = self.__get_options(rouge_args)
         command = [self._bin_path] + options
+        env = None
+        if hasattr(self, "_home_dir") and self._home_dir:
+            env = {'ROUGE_EVAL_HOME': self._home_dir}
         self.log.info(
             "Running ROUGE with command {}".format(" ".join(command)))
-        rouge_output = check_output(command).decode("UTF-8")
+        rouge_output = check_output(command, env=env).decode("UTF-8")
         return rouge_output
 
     def convert_and_evaluate(self, system_id=1,


### PR DESCRIPTION
Before, if user pass `rouge_dir`, the environment variable `ROUGE_EVAL_HOME` is not set, while the perl scripts need it! so user have to set it again in outer scripts or their bash profile.
After, we set it in the call process, so no extra setting will be need. User just need to pass the ROUGE perl home dir, and all is done.