### PR TITLE
Fix env variable when calling check_output

### DIFF
--- a/pyrouge/Rouge155.py
+++ b/pyrouge/Rouge155.py
@@ -334,9 +334,9 @@ class Rouge155(object):
         self.write_config(system_id=system_id)
         options = self.__get_options(rouge_args)
         command = [self._bin_path] + options
-        env = None
+        env = os.environ.copy()
         if hasattr(self, "_home_dir") and self._home_dir:
-            env = {'ROUGE_EVAL_HOME': self._home_dir}
+            env['ROUGE_EVAL_HOME'] = self._home_dir
         self.log.info(
             "Running ROUGE with command {}".format(" ".join(command)))
         rouge_output = check_output(command, env=env).decode("UTF-8")


### PR DESCRIPTION
The evaluate function currently sets the ROUGE_EVAL_HOME environment variable, but discards all others. This can cause failures when other environment variables are needed to run pyrouge. For example, we may need the PERL5LIB env variable to be able to locate certain Perl libraries needed to run ROUGE.

This PR fixes this by _copying the current OS environment variables_, and updating the ROUGE_EVAL_HOME one if needed, instead of only setting ROUGE_EVAL_HOME and discarding all others.