### PR TITLE
PyPI package outdated

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,7 +159,7 @@ To install pyrouge, run:
 
 ::
 
-    pip install pyrouge
+    pip install git+https://github.com/bheinzerling/pyrouge
     
 If you have trouble installing pyrouge on Windows, please check `this guide by Franck Dernoncourt <https://stackoverflow.com/questions/47045436/how-to-install-the-python-package-pyrouge-on-microsoft-windows/47045437#47045437>`_.
 


### PR DESCRIPTION
Running tests on the PyPI package causes failures because the scripts in `bin/` no longer have the `.py` extension.

Doing a pip install from the GitHub source fixes this.